### PR TITLE
do-release-tags: Add --create-missing-refs argument.

### DIFF
--- a/do-release-tags
+++ b/do-release-tags
@@ -28,7 +28,7 @@ def fatal(msg):
     sys.exit(1)
 
 parser = argparse.ArgumentParser(prog=sys.argv[0])
-parser.add_argument("--create-missing-refs", help="Create refs that don't already exist",
+parser.add_argument("--autocreate", help="Create refs that don't already exist",
 		    action='store_true')
 parser.add_argument("--ignore-no-previous-promotion", help="Releases file",
 		    action='store_true')

--- a/do-release-tags
+++ b/do-release-tags
@@ -28,6 +28,8 @@ def fatal(msg):
     sys.exit(1)
 
 parser = argparse.ArgumentParser(prog=sys.argv[0])
+parser.add_argument("--create-missing-refs", help="Create refs that don't already exist",
+		    action='store_true')
 parser.add_argument("--ignore-no-previous-promotion", help="Releases file",
 		    action='store_true')
 parser.add_argument("--repo", help="Repo path",
@@ -47,7 +49,11 @@ for (name,newcommit) in releasedata['releases'].iteritems():
     ref = baseref + name
     [_, current] = r.resolve_rev(ref, True)
     if current is None:
-        print("Ref {} does not currently exist".format(ref))
+        if args.create_missing_refs:
+            print("Creating new ref {}.".format(ref))
+            newparent = None
+        else:
+            fatal("error: Ref {} does not currently exist".format(ref))
     else:
         _,currentcommitdata,_ = r.load_commit(current)
         currentcommitmeta = currentcommitdata.get_child_value(0)


### PR DESCRIPTION
Gives the user a better error message if the ref is missing or give them the option to have it automatically created.  

See #3. 