### PR TITLE
print-summary: support URL path to summary file

### DIFF
--- a/print-summary
+++ b/print-summary
@@ -27,8 +27,7 @@ if args.path.startswith("http://") or args.path.startswith("https://"):
     if r.status_code != requests.codes.ok:
         print(r.headers)
         print(r.text)
-        print("ERROR: couldn't fetch summary file")
-        sys.exit(1)
+        fatal("Couldn't fetch summary file")
     bytedata = GLib.Bytes.new(r.content)
 else:
     with open(args.path) as f:

--- a/print-summary
+++ b/print-summary
@@ -25,9 +25,10 @@ args = parser.parse_args()
 if args.path.startswith("http://") or args.path.startswith("https://"):
     r = requests.get(args.path)
     if r.status_code != requests.codes.ok:
-        print("ERROR: couldn't fetch summary file:")
         print(r.headers)
         print(r.text)
+        print("ERROR: couldn't fetch summary file")
+        sys.exit(1)
     bytedata = GLib.Bytes.new(r.content)
 else:
     with open(args.path) as f:

--- a/print-summary
+++ b/print-summary
@@ -11,7 +11,7 @@ from __future__ import print_function
 import gi
 gi.require_version('OSTree', '1.0')
 from gi.repository import GLib, Gio, OSTree
-import argparse, os, sys
+import argparse, os, sys, requests
 
 def fatal(msg):
     print >>sys.stderr, msg
@@ -22,8 +22,16 @@ parser.add_argument("path", help="Summary path as file",
                     action='store')
 args = parser.parse_args()
 
-with open(args.path) as f:
-    bytedata = GLib.Bytes.new(f.read())
+if args.path.startswith("http://") or args.path.startswith("https://"):
+    r = requests.get(args.path)
+    if r.status_code != requests.codes.ok:
+        print("ERROR: couldn't fetch summary file:")
+        print(r.headers)
+        print(r.text)
+    bytedata = GLib.Bytes.new(r.content)
+else:
+    with open(args.path) as f:
+        bytedata = GLib.Bytes.new(f.read())
 typestr = GLib.VariantType.new('(a(s(taya{sv}))a{sv})')
 d = GLib.Variant.new_from_bytes(typestr, bytedata, False)
 


### PR DESCRIPTION
It's just more convenient to be able to just paste in the summary URL
directly without having to download it first.