### PR TITLE
find-object-filenames: Search for file path to object

### DIFF
--- a/find-object-filenames
+++ b/find-object-filenames
@@ -1,0 +1,60 @@
+#!/usr/bin/env python
+#
+# Find all ref,filename pairs pointing to target file object
+#
+# Copyright 2017 Colin Walters <walters@verbum.org>
+# Licensed under the new-BSD license (http://www.opensource.org/licenses/bsd-license.php)
+
+import gi
+gi.require_version('OSTree', '1.0')
+import sys,os,argparse
+from gi.repository import GLib, Gio, OSTree
+
+def fatal(msg):
+    print >>sys.stderr, msg
+    sys.exit(1)
+
+parser = argparse.ArgumentParser()
+parser.add_argument("--repo", help="Repo",
+                    action='store', required=True)
+parser.add_argument("--object", '-o', help="Object",
+                    action='store', required=True)
+parser.add_argument("--rev", '-e', help="Find starting from rev",
+                    action='store')
+
+args = parser.parse_args()
+
+repopath = args.repo
+obj = getattr(args, 'object')
+
+r = OSTree.Repo.new(Gio.File.new_for_path(repopath))
+r.open(None)
+
+def find_object_recurse(findstate, d, obj, cancellable):
+    e = d.enumerate_children('standard::name,standard::type', 0, cancellable)
+    while True:
+        try:
+            [_,info,child] = e.iterate(cancellable)
+        except GLib.Error as e:
+            sys.stderr.write("Processing: {} => {} : {}".format(findstate[0], findstate[1], child.get_path()))
+            raise e
+        if info is None:
+            break
+        if info.get_file_type() == Gio.FileType.DIRECTORY:
+            find_object_recurse(findstate, child, obj, cancellable)
+        else:
+            if child.get_checksum() == obj:
+                print("{} => {} : {}".format(findstate[0], findstate[1], child.get_path()))
+
+cancellable = None
+if not args.rev:
+    [_,refs] = r.list_refs(None, None)
+    print("Searching {} refs for {}".format(len(refs), obj))
+    for ref in refs:
+        [_,root,rev] = r.read_commit(ref, None)
+        findstate = (ref, rev,)
+        find_object_recurse(findstate, root, obj, cancellable)
+else:
+    [_,root,rev] = r.read_commit(args.rev, None)
+    findstate = (args.rev, rev,)
+    find_object_recurse(findstate, root, obj, cancellable)


### PR DESCRIPTION
Given a content object checksum, print all (ref, path) pairs
that point to it.  May also optionally start from just a single
ref/commit.

I am debugging an object being missing in rpm-ostree jigdo and
this was useful.