### PR TITLE
rpm-ostree-bisect: updates to handle package layering, read-only /sysroot

### DIFF
--- a/rpm-ostree-bisect
+++ b/rpm-ostree-bisect
@@ -97,6 +97,39 @@ def log(msg):
     print(msg)
     sys.stdout.flush()
 
+"""
+    Find out of the given commitid is a base commit (i.e. no
+    layered packages). We'll cue off of the `rpmostree.clientlayer`
+    metadata for this.
+"""
+def is_base_commit(repo, commitid):
+    # Grab commit object. If None then history has been
+    # trimmed from the remote and we can break
+    _, commit = repo.load_variant_if_exists(
+                    OSTree.ObjectType.COMMIT, commitid)
+    # Grab version info from commit
+    meta = commit.get_child_value(0)
+    clientlayer = meta.lookup_value('rpmostree.clientlayer', GLib.VariantType.new('b'))
+    if clientlayer:
+        return False
+    else:
+        return True
+
+
+"""
+    Find the base commit of the deployment for the system. This
+    only differs from what you would expect if the system has
+    layered packages.
+"""
+def get_deployed_base_commit(deployment, repo):
+    commitid = deployment.get_csum()
+    if not is_base_commit(repo, commitid):
+        _, commit = repo.load_variant_if_exists(
+                        OSTree.ObjectType.COMMIT, commitid)
+        commitid = OSTree.commit_get_parent(commit)
+    return commitid
+
+
 """ 
     Initialize commit info ordered dict. The array will be a list of 
     commits in descending order. Each entry will be a dict with 
@@ -166,6 +199,7 @@ def initialize_commits_info(repo, bad, good):
 
     return info
 
+
 """
     Grab all commit history from the remote (just
     the metadata).
@@ -173,10 +207,14 @@ def initialize_commits_info(repo, bad, good):
 def pull_commit_history(deployment, repo):
 
     # Get repo, remote and refspec from the booted deployment
+    # The refspec in the metadata is either `refspec` if there
+    # are no layered packages (i.e. the deployed commit is a base
+    # commit) or `baserefspec` if there are.
     origin = deployment.get_origin()
-    refspec = origin.get_string('origin', 'refspec')
-    # with layered packages it has baserefspec
-    #refspec = origin.get_string('origin', 'baserefspec')
+    if is_base_commit(repo, deployment.get_csum()):
+        refspec = origin.get_string('origin', 'refspec')
+    else:
+        refspec = origin.get_string('origin', 'baserefspec')
     _, remote, ref = OSTree.parse_refspec(refspec)
 
     # Build up options array for pull call
@@ -198,12 +236,14 @@ def pull_commit_history(deployment, repo):
     #progress2 = OSTree.AsyncProgress.new_and_connect(OSTree.Repo.pull_default_console_progress_changed(progress, None), None)
     repo.pull_with_options(remote, options, progress, None) 
 
+
 def load_data(datafile):
     with open(datafile, 'r') as f:
         data = json.load(f, object_pairs_hook=OrderedDict)
     commits_info = data['commits_info']
     testscript = data['test_script']
     return commits_info, testscript
+
 
 def write_data(datafile, commits_info, testscript):
     data = { 'commits_info': commits_info,
@@ -241,7 +281,7 @@ def bisect_start(args, deployment, repo):
     # Assume currently booted commit is bad if no
     # bad commit was given
     if badcommit is None:
-        badcommit = deployment.get_csum()
+        badcommit = get_deployed_base_commit(deployment, repo)
 
     # pull commit history
     pull_commit_history(deployment, repo)
@@ -283,7 +323,7 @@ def bisect_resume(args, deployment, repo):
         success = False
 
     # update and write data
-    commit = deployment.get_csum()
+    commit = get_deployed_base_commit(deployment, repo)
     if success:
         for c in reversed(commits_info.keys()):
             commits_info[c]['status'] = 'GOOD' 

--- a/rpm-ostree-bisect
+++ b/rpm-ostree-bisect
@@ -129,6 +129,18 @@ def get_deployed_base_commit(deployment, repo):
         commitid = OSTree.commit_get_parent(commit)
     return commitid
 
+"""
+    On newer rpm-ostree systems /sysroot has been mounted read-only
+    which means we can't pull commit metadata into the repo. Let's
+    remount it read-write if that's the case.
+"""
+def make_sysroot_readwrite():
+    stat = os.statvfs('/sysroot')
+    readonly = bool(stat.f_flag & os.ST_RDONLY)
+    if readonly:
+        cmd = ['/usr/bin/mount', '-o', 'remount,rw', '/sysroot']
+        subprocess.call(cmd)
+
 
 """ 
     Initialize commit info ordered dict. The array will be a list of 
@@ -432,6 +444,8 @@ def main():
     if deployment is None:
         fatal("Not in a booted OSTree system!")
     _, repo = sysroot.get_repo(None)
+
+    make_sysroot_readwrite()
 
     log("Using data file at: %s" % args.datafile)
 

--- a/rpm-ostree-bisect
+++ b/rpm-ostree-bisect
@@ -216,11 +216,17 @@ def pull_commit_history(deployment, repo):
     # Get repo, remote and refspec from the booted deployment
     # The refspec in the metadata is either `refspec` if there
     # are no layered packages (i.e. the deployed commit is a base
-    # commit) or `baserefspec` if there are.
+    # commit) or `baserefspec` if there are or ever have been.
+    # Try first for `refspec` and fall back to `baserefspec.
     origin = deployment.get_origin()
-    if is_base_commit(repo, deployment.get_csum()):
+    refspec = ""
+    try:
         refspec = origin.get_string('origin', 'refspec')
-    else:
+    except GLib.Error as e:
+        # If not a "key not found" error then raise the exception
+        if not e.matches(GLib.KeyFile.error_quark(), GLib.KeyFileError.KEY_NOT_FOUND):
+            raise(e)
+        # Fallback to `baserefspec`
         refspec = origin.get_string('origin', 'baserefspec')
     _, remote, ref = OSTree.parse_refspec(refspec)
 

--- a/rpm-ostree-bisect
+++ b/rpm-ostree-bisect
@@ -98,22 +98,17 @@ def log(msg):
     sys.stdout.flush()
 
 """
-    Find out of the given commitid is a base commit (i.e. no
-    layered packages). We'll cue off of the `rpmostree.clientlayer`
-    metadata for this.
+    Find out of the given commitid is a layered commit (i.e. layered
+    packages). We'll cue off of the `rpmostree.clientlayer` metadata for this.
 """
-def is_base_commit(repo, commitid):
+def is_layered_commit(repo, commitid):
     # Grab commit object. If None then history has been
     # trimmed from the remote and we can break
     _, commit = repo.load_variant_if_exists(
                     OSTree.ObjectType.COMMIT, commitid)
     # Grab version info from commit
     meta = commit.get_child_value(0)
-    clientlayer = meta.lookup_value('rpmostree.clientlayer', GLib.VariantType.new('b'))
-    if clientlayer:
-        return False
-    else:
-        return True
+    return meta.lookup_value('rpmostree.clientlayer', GLib.VariantType.new('b'))
 
 
 """
@@ -123,7 +118,7 @@ def is_base_commit(repo, commitid):
 """
 def get_deployed_base_commit(deployment, repo):
     commitid = deployment.get_csum()
-    if not is_base_commit(repo, commitid):
+    if is_layered_commit(repo, commitid):
         _, commit = repo.load_variant_if_exists(
                         OSTree.ObjectType.COMMIT, commitid)
         commitid = OSTree.commit_get_parent(commit)

--- a/rpm-ostree-bisect
+++ b/rpm-ostree-bisect
@@ -124,18 +124,6 @@ def get_deployed_base_commit(deployment, repo):
         commitid = OSTree.commit_get_parent(commit)
     return commitid
 
-"""
-    On newer rpm-ostree systems /sysroot has been mounted read-only
-    which means we can't pull commit metadata into the repo. Let's
-    remount it read-write if that's the case.
-"""
-def make_sysroot_readwrite():
-    stat = os.statvfs('/sysroot')
-    readonly = bool(stat.f_flag & os.ST_RDONLY)
-    if readonly:
-        cmd = ['/usr/bin/mount', '-o', 'remount,rw', '/sysroot']
-        subprocess.call(cmd)
-
 
 """ 
     Initialize commit info ordered dict. The array will be a list of 
@@ -230,24 +218,12 @@ def pull_commit_history(deployment, repo):
         refspec = origin.get_string('origin', 'baserefspec')
     _, remote, ref = OSTree.parse_refspec(refspec)
 
-    # Build up options array for pull call
-    #   refs (as): Array of string refs
-    #   flags (i): An instance of OSTree.RepoPullFlags
-    #   depth (i): How far in the history to traverse; default is 0, -1 means infinite
-    # More info on Gvariant types:
-    #   https://lazka.github.io/pgi-docs/GLib-2.0/classes/VariantType.html#GLib.VariantType
-    flags = OSTree.RepoPullFlags(2) # COMMIT_ONLY = 2 Only pull commit metadata
-    depth = -1 # -1 means max depth
-    options = GLib.Variant('a{sv}', {
-        'refs': GLib.Variant('as', [ref]),
-        'flags': GLib.Variant('i', flags),
-        'depth': GLib.Variant('i', depth),
-    })
-
-    # Grab commit metadata history for ref from repo
-    progress = OSTree.AsyncProgress.new()
-    #progress2 = OSTree.AsyncProgress.new_and_connect(OSTree.Repo.pull_default_console_progress_changed(progress, None), None)
-    repo.pull_with_options(remote, options, progress, None) 
+    # Run the ostree pull operation. Use the binary here rather than
+    # the Python API because binary will properly remount /sysroot
+    # read/write on systems that have it mounted read-only.
+    cmd = ['/usr/bin/ostree', 'pull',
+                '--commit-metadata-only', '--depth=-1', f'{remote}:{ref}']
+    subprocess.call(cmd)
 
 
 def load_data(datafile):
@@ -445,8 +421,6 @@ def main():
     if deployment is None:
         fatal("Not in a booted OSTree system!")
     _, repo = sysroot.get_repo(None)
-
-    make_sysroot_readwrite()
 
     log("Using data file at: %s" % args.datafile)
 


### PR DESCRIPTION
```
commit 1f7107cfae10cdf467a2d8e777ea4ec35e6b628b
Author: Dusty Mabe <dusty@dustymabe.com>
Date:   Fri Nov 6 15:55:28 2020 -0500

    rpm-ostree-bisect: support read-only /sysroot/
    
    On newer rpm-ostree systems /sysroot can be mounted read-only [1]
    which means we can't pull commit metadata into the repo. Let's
    remount it read-write if that's the case.
    
    [1] https://github.com/ostreedev/ostree/pull/1767

commit 295dd7b328a6b14a8cb9178b39fdc01f1fe81230
Author: Dusty Mabe <dusty@dustymabe.com>
Date:   Mon Nov 2 23:06:09 2020 -0500

    rpm-ostree-bisect: support systems with layered packages
    
    Add new functions to determine if the system is operating with layered
    packages or not and properly detect the base commit if so.
```
