### PR TITLE
rsync-repos: Also track config and summaries

### DIFF
--- a/rsync-repos
+++ b/rsync-repos
@@ -50,7 +50,8 @@ def rsync(paths, opts, ignore_missing_args=False):
     subprocess.check_call(argv)
 
 OBJECTS_AND_DELTAS = ['/objects', '/objects/**', '/deltas', '/deltas/**']
-REFS_AND_SUMMARY = ['/refs', '/refs/**', '/summary*']
+REFS_AND_SUMMARY = ['/refs', '/refs/**', '/summary*', '/summaries', '/summaries/**']
+CONFIG = ['/config']
 # We rsync in reverse data dependence order - the summary and refs
 # point to objects + deltas.  Our first pass over the objects doesn't
 # perform any deletions, as that would create race conditions.  We
@@ -59,3 +60,4 @@ rsync(OBJECTS_AND_DELTAS, ['--ignore-existing'])
 rsync(REFS_AND_SUMMARY, ['--delete'])
 # Finally, we handle any deletions for objects and deltas.
 rsync(OBJECTS_AND_DELTAS, ['--ignore-existing', '--delete'])
+rsync(CONFIG, ['--ignore-existing'])


### PR DESCRIPTION
Flatpak 1.9.x cycle introduced a new summary format with sub summaries, stored inside tgz files in the '/summaries' repository. (flatpak/flatpak@0597f246c80ccd5e5ef72767744b3c634718ece6)
    
Also, sync the repository config file. This will avoid failures when trying to build on top of existing repos pulled with rsync-repos instead of having to create it.
